### PR TITLE
Minor changes

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -18,3 +18,6 @@ if [[ -r ~/.credentials ]]; then
 fi
 
 # export PROMPT_COMMAND="_update_ps1"
+
+# Start bash, then switch to zsh embedded in bash
+[[ $(which zsh)=0 ]] && exec -l zsh "$@"

--- a/.tmux.conf
+++ b/.tmux.conf
@@ -68,9 +68,10 @@ setw -g mode-keys vi
 # Copy mode
 bind ` copy-mode
 unbind [
-unbind p
-bind p paste-buffer
-bind-key -T copy-mode-vi Escape send -X cancel
+bind-key -T copy-mode-vi v send-keys -X begin-selection
+bind-key -T copy-mode-vi y send-keys -X copy-selection
+bind-key -T copy-mode-vi r send-keys -X rectangle-toggle
+bind-key -T copy-mode-vi Escape send-keys -X cancel
 
 # Apply some overrides to the defaults
 set-option -g status-position top

--- a/.zshrc
+++ b/.zshrc
@@ -29,7 +29,7 @@ zgenom() {
 }
 
 # Generate zgenom init script if needed
-if [[ ! -s ${ZDOTDIR:-${HOME}}/.zgenom/sources/init.zsh ]]; then
+if ! zgenom saved; then
   zgenom load zsh-users/zsh-autosuggestions
   zgenom load zdharma-continuum/fast-syntax-highlighting
   zgenom load zsh-users/zsh-history-substring-search

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ This setup will work on both OSX and Linux (and may work on other platforms).
 ![](Screenshots/Dotfiles.png)
 
 ## Requirements
+* You have `exa` installed (`ls` replacement, e.g. `cargo install exa`)
 * You have `zsh` installed (known to work from 4.3.17 to 5.3.1)
 * You have `tmux` installed (`2.1`+ or you will have issues with the supplied `.tmux.conf` )
 * You have `vim` installed (optionally compiled with `ruby` and `python` support)


### PR DESCRIPTION
* Make `zsh` run from bash
* Bind more reasonable Vim keys for Tmux 2.4+
* Use `zgenom saved`
* Add `exa` requirement (otherwise `ls` fails)